### PR TITLE
Upload IP Addrs to DHT

### DIFF
--- a/lib/handlers/nostr/kind11011/kind11011handler.go
+++ b/lib/handlers/nostr/kind11011/kind11011handler.go
@@ -203,7 +203,7 @@ func HandleRelayList(event nostr.Event) error {
 		}
 	}
 
-	err = relayStore.AddUploadable(payload, pubkey, sig, true)
+	err = relayStore.AddUploadable(payload, pubkey, "", sig, true)
 	if err != nil {
 		log.Printf("Error adding uploadable to sync store: %v", err)
 		return errors.New("error adding upload to sync store")

--- a/lib/sync/sync-store.go
+++ b/lib/sync/sync-store.go
@@ -23,6 +23,7 @@ type DHTUploadable struct {
 	gorm.Model
 	Payload   []byte
 	Pubkey    []byte
+	Salt      []byte
 	Signature []byte
 }
 
@@ -93,7 +94,7 @@ func PutSyncRelay(db *gorm.DB, publicKey string, relayInfo interface{}) error {
 }
 
 // PutDHTUploadable adds or updates a DHTUploadable
-func PutDHTUploadable(db *gorm.DB, payload []byte, pubkey []byte, signature []byte) error {
+func PutDHTUploadable(db *gorm.DB, payload []byte, pubkey []byte, salt []byte, signature []byte) error {
 	var dhtUploadable DHTUploadable
 	result := db.Where("pubkey = ?", pubkey).First(&dhtUploadable)
 
@@ -103,6 +104,7 @@ func PutDHTUploadable(db *gorm.DB, payload []byte, pubkey []byte, signature []by
 			dhtUploadable = DHTUploadable{
 				Payload:   payload,
 				Pubkey:    pubkey,
+				Salt:      salt,
 				Signature: signature,
 			}
 			return db.Create(&dhtUploadable).Error
@@ -111,6 +113,7 @@ func PutDHTUploadable(db *gorm.DB, payload []byte, pubkey []byte, signature []by
 	}
 	// Update existing record
 	dhtUploadable.Payload = payload
+	dhtUploadable.Salt = salt
 	dhtUploadable.Signature = signature
 	return db.Save(&dhtUploadable).Error
 }


### PR DESCRIPTION
- Slight refactor to account for multiple bep44 messages indexed by different salts
- Every time we go to re-upload any uploadables (relay-lists) in the db, we also re-upload our own multiaddr list (at the "MultiAddrs" salt)

Plz check that I'm using the right viper keys here. It might be helpful to have an example config.json that works out of the box.