### PR TITLE
Add free tier auth improvements

### DIFF
--- a/lib/handlers/scionic/upload/upload.go
+++ b/lib/handlers/scionic/upload/upload.go
@@ -193,7 +193,7 @@ func BuildUploadStreamHandler(store stores.Store, canUploadDag func(rootLeaf *me
 
 		fmt.Println("Dag verified")
 
-		// Check to see if any data in the dag is not allows to be stored by this relay
+		// Check to see if any data in the dag is not allowed to be stored by this relay
 		for _, leaf := range dag.Leafs {
 			if leaf.Type == "File" {
 				data, err := dag.GetContentFromLeaf(leaf)
@@ -208,12 +208,8 @@ func BuildUploadStreamHandler(store stores.Store, canUploadDag func(rootLeaf *me
 					write(utils.BuildErrorMessage("Mime type is not allowed to be stored by this relay ("+mimeType.String()+")", err))
 					return
 				}
-
-				store.GetStatsStore().SaveFile(dag.Root, leaf.Hash, leaf.ItemName, mimeType.String(), len(leaf.Links), int64(len(data)))
 			}
 		}
-
-		fmt.Println("Files saved to stats")
 
 		dagData.Dag = *dag
 

--- a/lib/web/handler_relay_count.go
+++ b/lib/web/handler_relay_count.go
@@ -21,8 +21,8 @@ func getRelayCount(c *fiber.Ctx, store stores.Store) error {
 	for group, types := range relaySettings.MimeTypeGroups {
 		for _, mimeType := range types {
 			amount, err := store.GetStatsStore().FetchFileCountByType(mimeType)
-			if err == nil {
-				continue
+			if err != nil {
+				continue // Skip if there's an error fetching count
 			}
 
 			if _, ok := responseData[group]; !ok {
@@ -31,6 +31,12 @@ func getRelayCount(c *fiber.Ctx, store stores.Store) error {
 
 			responseData[group] += amount
 		}
+	}
+
+	// Add notes count (Nostr events) to the response
+	noteCount, err := store.GetStatsStore().FetchKindCount()
+	if err == nil { // Only add if there was no error
+		responseData["Notes"] = noteCount
 	}
 
 	// Respond with the aggregated counts


### PR DESCRIPTION
## Summary
  - Add tracking for Nostr event statistics in the `kinds` table
  - Implement user profile tracking for kind 0 events
  - Add file and MIME type statistics for blobs and DAG content
  - Fix relay count handler to match frontend expectations

  ## Technical Details
  - Added statistics tracking to `StoreEvent` method for Nostr events
  - Enhanced `StoreBlob` to record file information with MIME type detection
  - Updated `StoreLeaf` to track DAG content statistics and tags
  - Fixed the relay count handler to use the correct field names expected by the frontend
  - Created mapping between backend MIME type groups and frontend categories

  ## Test plan
  - Verify events are being tracked in the kinds table
  - Confirm user profiles are being recorded for kind 0 events
  - Check that file information is being stored with correct MIME types
  - Ensure the relay count endpoint returns data in the expected format