### PR TITLE
Enhancement: Exempt User's Own Notes from Content Filtering

### DIFF
--- a/lib/handlers/nostr/filter/filter.go
+++ b/lib/handlers/nostr/filter/filter.go
@@ -266,7 +266,11 @@ func BuildFilterHandler(store stores.Store) func(read lib_nostr.KindReader, writ
 				var nonFilterableEvents []*nostr.Event
 
 				for _, e := range uniqueEvents {
-					if filterService.ShouldFilterKind(e.Kind) {
+					if e.PubKey == connPubkey {
+						nonFilterableEvents = append(nonFilterableEvents, e)
+						log.Printf(ColorGreenBold+"[CONTENT FILTER] EXEMPT EVENT: ID=%s, Kind=%d, PubKey=%s (authored by requester)"+ColorReset,
+							e.ID, e.Kind, e.PubKey)
+					} else if filterService.ShouldFilterKind(e.Kind) {
 						filterableEvents = append(filterableEvents, e)
 					} else {
 						nonFilterableEvents = append(nonFilterableEvents, e)


### PR DESCRIPTION
## Summary
This pull request introduces an enhancement to the content filtering mechanism in the HORNETS-Nostr-Relay project. The change ensures that users' own notes are exempt from content filtering, preventing the illogical scenario of self-censorship while maintaining the ability to filter content from other users based on preferences specified in kind 10010 events.

## Changes Made
- Modified the filtering logic in lib/handlers/nostr/filter/filter.go to check if an event's author matches the authenticated public key of the requester.
- Added a condition to categorize the user's own events as non-filterable, ensuring they bypass content filtering regardless of event kind.
- Enhanced logging to indicate when an event is exempted from filtering because it was authored by the requester, aiding in transparency and debugging.

## Impact
- Users will now see all of their own content unfiltered, improving the user experience by avoiding self-censorship.
- The filtering of content from other users remains unchanged, respecting the preferences set in kind 10010 events.
- This change maintains the privacy and integrity of the content filtering system while addressing a key usability concern.
