### PR TITLE
Kind10010 restructure

### DIFF
--- a/docs/NIP-889.md
+++ b/docs/NIP-889.md
@@ -1,0 +1,139 @@
+# NIP-889: Private Content Filtering Preferences
+`draft` `optional`
+
+## Abstract
+This NIP defines a standard for users to express their content filtering preferences using kind 10010 events. These preferences allow compatible relays and clients to filter content based on user-defined instructions and muted words, while ensuring that these preferences remain private to the user who created them.
+
+## Motivation
+Users often want to customize their feed experience by filtering out content they're not interested in or find objectionable. By standardizing how these preferences are expressed, relays and clients can implement consistent filtering mechanisms that respect user choices while maintaining privacy.
+
+## Specification
+
+### Event Structure
+Content filtering preferences are expressed using events with `kind: 10010`.
+
+```json
+{
+  "kind": 10010,
+  "created_at": <unix timestamp in seconds>,
+  "content": <filtering instructions as plain text>,
+  "tags": [
+    ["enabled", <"true" or "false">],
+    ["mute", <comma-separated list of words to mute>]
+  ],
+  "pubkey": <32-bytes lowercase hex-encoded public key of the event creator>,
+  "id": <32-bytes lowercase hex-encoded sha256 of the serialized event data>,
+  "sig": <64-bytes lowercase hex of the signature>
+}
+```
+
+### Fields
+
+- **content**: Contains the filtering instructions as plain text. These instructions describe what content the user wants to see or filter out. The format is free-form text that can be interpreted by compatible filtering systems.
+
+### Tags
+
+- **enabled**: A boolean flag indicating if filtering is enabled.
+  - Format: `["enabled", "true"]` or `["enabled", "false"]`
+  - Required: Yes
+
+- **mute**: A comma-separated list of words or phrases that should be muted.
+  - Format: `["mute", "word1,word2,word3"]`
+  - Required: No, but recommended to include even if empty (`["mute", ""]`)
+
+### Privacy Model
+
+Unlike most Nostr events which are public, kind 10010 events are treated as private to the user who created them:
+
+1. Relays MUST NOT send kind 10010 events to any user other than the author of the event.
+2. When a user requests events, relays MUST filter out kind 10010 events that were not created by that user.
+3. Clients SHOULD NOT display kind 10010 events from other users, even if they are received.
+
+This privacy model ensures that a user's filtering preferences remain confidential and are only used to filter content for that specific user.
+
+### Processing Rules
+
+1. Relays SHOULD treat these events as replaceable (only the latest event per pubkey should be stored).
+2. The filtering instructions in the `content` field SHOULD be interpreted as human-readable guidelines for content filtering.
+3. The `mute` tag SHOULD be used for exact word or phrase matching, where posts containing any of the listed words would be filtered out.
+4. When the `enabled` tag is set to `"false"`, clients and relays SHOULD NOT apply any filtering based on this event.
+
+### Implementation Approaches
+
+Implementations may use different approaches to apply these filtering preferences:
+
+1. **Client-side filtering**: Clients can filter received events based on the user's preferences.
+2. **Relay-side filtering**: Relays that support this NIP can filter events before sending them to users.
+3. **AI-assisted filtering**: The instructions in the `content` field can be used with language models to determine if content matches the user's preferences.
+
+## Examples
+
+### Basic Filtering Instructions
+
+```json
+{
+  "kind": 10010,
+  "created_at": 1715027400,
+  "content": "I want to filter my Nostr feed based on these preferences:\nRule 1: Include content about technology and programming.\nRule 2: Filter out political content.\nRule 3: Include thoughtful discussions, even if controversial.",
+  "tags": [
+    ["enabled", "true"],
+    ["mute", "spam,scam,airdrop"]
+  ],
+  "pubkey": "32-bytes-hex",
+  "id": "32-bytes-hex",
+  "sig": "64-bytes-hex"
+}
+```
+
+### Disabled Filtering
+
+```json
+{
+  "kind": 10010,
+  "created_at": 1715027400,
+  "content": "I want to filter my Nostr feed based on these preferences:\nRule 1: Include content about technology and programming.\nRule 2: Filter out political content.",
+  "tags": [
+    ["enabled", "false"],
+    ["mute", ""]
+  ],
+  "pubkey": "32-bytes-hex",
+  "id": "32-bytes-hex",
+  "sig": "64-bytes-hex"
+}
+```
+
+## Privacy Considerations
+
+Content filtering preferences are private events on the Nostr network, which means they should only be visible to the user who created them. This is enforced by relay implementations that:
+
+1. Only send kind 10010 events to the user who authored them
+2. Filter out kind 10010 events from other users when responding to queries
+3. Ensure that a user's filtering preferences are not visible to other users
+
+This privacy model differs from most Nostr events, which are typically public. The private nature of kind 10010 events ensures that users can express their content preferences without revealing potentially sensitive information about their interests or sensitivities.
+
+## Client Behavior
+
+Clients that support this NIP SHOULD:
+
+1. Provide a user interface for creating and editing content filtering preferences
+2. Apply filtering based on the user's preferences when displaying content
+3. Clearly indicate when content is being filtered and provide options to view filtered content
+4. Never display kind 10010 events from other users, even if they are received
+
+## Relay Behavior
+
+Relays that support this NIP MUST:
+
+1. Store kind 10010 events as replaceable events
+2. Only send kind 10010 events to the user who authored them
+3. Filter out kind 10010 events from other users when responding to queries
+
+Relays MAY:
+
+1. Filter events sent to users based on their filtering preferences
+2. Indicate to clients when filtering has been applied
+
+## Compatibility
+
+This NIP is compatible with all existing Nostr clients and relays. Clients and relays that do not support this NIP will simply ignore kind 10010 events.

--- a/docs/moderation_modes.md
+++ b/docs/moderation_modes.md
@@ -1,0 +1,78 @@
+# Moderation Modes
+
+HORNETS-Nostr-Relay supports two moderation modes for handling events with media content that requires moderation:
+
+## Strict Mode (Default)
+
+In strict mode, events with media content (images, videos) are not queryable by regular users while they are pending moderation. This ensures that potentially problematic content is not visible to users until it has been properly moderated.
+
+However, the authors of the events can still query their own events even while they are pending moderation. This allows authors to see their own content immediately after posting, providing a better user experience for content creators.
+
+Once moderation is complete:
+- Events that pass moderation become queryable by everyone
+- Events that fail moderation are blocked and not queryable by anyone
+
+## Passive Mode
+
+In passive mode, events with media content are queryable by everyone while they are pending moderation. This provides a more immediate user experience, as content is visible right away without waiting for moderation.
+
+Once moderation is complete:
+- Events that pass moderation remain queryable by everyone
+- Events that fail moderation are blocked and not queryable by anyone
+
+## Configuration
+
+The moderation mode can be configured in your `config.json` file:
+
+```json
+{
+  "moderation_mode": "strict"
+}
+```
+
+To change to passive mode:
+
+```json
+{
+  "moderation_mode": "passive"
+}
+```
+
+If not specified, the default mode is "strict".
+
+## Implementation Details
+
+The moderation system works as follows:
+
+1. When an event with media content is submitted, it's added to the pending moderation queue
+2. The moderation worker processes events in the queue by analyzing the media content
+3. Based on the moderation result, the event is either approved or blocked
+4. The query filtering system applies the appropriate visibility rules based on the configured moderation mode
+
+### Moderation Flow
+
+```mermaid
+graph TD
+    A[Event Submitted] --> B[Extract Media URLs]
+    B --> C{Has Media?}
+    C -->|Yes| D[Add to Pending Moderation Queue]
+    C -->|No| E[Store Event]
+    D --> F[Background Moderation Worker]
+    F --> G{Moderation Result}
+    G -->|Pass| H[Remove from Pending Queue]
+    G -->|Fail| I[Mark as Blocked]
+    H --> E
+    I --> J[Create Moderation Notification]
+    
+    K[Client Query] --> L{Moderation Mode?}
+    L -->|Strict| M{Is Author?}
+    L -->|Passive| N[Include Pending Events]
+    M -->|Yes| N
+    M -->|No| O[Exclude Pending Events]
+    N --> P{Is Blocked?}
+    O --> P
+    P -->|Yes| Q[Exclude Event]
+    P -->|No| R[Include Event]
+```
+
+This moderation system provides flexibility while ensuring that inappropriate content can be filtered out effectively.

--- a/lib/handlers/nostr/contentfilter/README.md
+++ b/lib/handlers/nostr/contentfilter/README.md
@@ -4,7 +4,12 @@ This package implements personalized content filtering for Nostr events via dire
 
 ## Overview
 
-The content filtering system enables users to create customized feeds based on their preferences by directly leveraging local Large Language Models (LLMs) via Ollama. This streamlined architecture eliminates the need for an intermediate API server.
+The content filtering system enables users to create customized feeds based on their preferences. It offers two filtering methods:
+
+1. **Mute Word Filtering**: Available to all users, this simple string-matching filter removes content containing specific words.
+2. **AI-Based Filtering**: Available only to paid subscribers, this advanced filtering uses local Large Language Models (LLMs) via Ollama to intelligently filter content based on custom instructions.
+
+This streamlined architecture eliminates the need for an intermediate API server while preserving server resources by limiting AI filtering to paid users.
 
 ```mermaid
 flowchart TD
@@ -23,20 +28,36 @@ flowchart TD
 
 To enable content filtering, send a kind 10010 event to the relay with your filtering preferences:
 
+#### Using Mute Words (Available to All Users)
+
 ```json
 {
   "kind": 10010,
-  "content": "{\"enabled\":true,\"instructions\":\"I want to filter my Nostr feed based on these preferences:\\nRule 1: Include content about technology and programming.\\nRule 2: Filter out political content.\\nRule 3: Include thoughtful discussions, even if controversial.\"}"
+  "content": "I want to filter my feed",
+  "tags": [
+    ["enabled", "true"],
+    ["mute", "politics,spam,nsfw"]
+  ]
 }
 ```
 
-The `content` field can have two formats:
+The mute words tag contains a comma-separated list of words to filter out. Any post containing these words will be removed from your feed.
 
-1. **JSON string** with:
-   - `enabled`: Boolean indicating if filtering is active
-   - `instructions`: String with your custom instructions
+#### Using AI Filtering (Paid Subscribers Only)
 
-2. **Plain text** instructions (in this case, filtering is assumed to be enabled)
+```json
+{
+  "kind": 10010,
+  "content": "I want to filter my Nostr feed based on these preferences:\nRule 1: Include content about technology and programming.\nRule 2: Filter out political content.\nRule 3: Include thoughtful discussions, even if controversial.",
+  "tags": [
+    ["enabled", "true"]
+  ]
+}
+```
+
+The `content` field contains your custom filtering instructions that will be processed by the AI model. This feature is only available to users with a paid subscription.
+
+> **Note**: You can use both mute words and AI filtering together if you're a paid subscriber.
 
 ### 2. Update Your Preferences
 
@@ -57,9 +78,19 @@ To disable filtering, send a kind 10010 event with filtering disabled:
 
 After enabling filtering, all kind 1 (text note) events you request through the relay will automatically be filtered according to your preferences. No additional action is needed.
 
-## Example Filter Instructions
+## Example Filtering Options
 
-You can customize your filters with any instructions. Here are some examples:
+### Mute Word Examples (All Users)
+
+Simple word lists that will filter out posts containing these terms:
+
+- Basic filtering: `politics,spam,nsfw,gambling`
+- Cryptocurrency spam: `airdrop,free tokens,giveaway,get rich`
+- Content warnings: `gore,violence,disturbing`
+
+### AI Filter Instructions (Paid Subscribers Only)
+
+You can customize your AI filters with any instructions. Here are some examples:
 
 **Technology Focus**
 ```
@@ -77,6 +108,33 @@ Rule 2: Filter out financial and market discussions.
 Rule 3: Include content with images and embedded media.
 ```
 
+## Subscription Requirements
+
+The filtering system has different capabilities depending on your subscription status:
+
+| Feature | Free Users | Paid Subscribers |
+|---------|------------|------------------|
+| Mute Word Filtering | ✅ Available | ✅ Available |
+| AI-Based Filtering | ❌ Not available | ✅ Available (active subscriptions only) |
+| Custom Instructions | ❌ Not available | ✅ Available (active subscriptions only) |
+| Number of Mute Words | Unlimited | Unlimited |
+
+**Important**: AI filtering is only available to paid subscribers with active (non-expired) subscriptions. Once a subscription expires, the user will still have access to mute word filtering but will lose access to AI filtering until they renew their subscription.
+
+To upgrade to a paid subscription and access AI filtering, please refer to the relay's subscription options.
+
+## Subscription Verification
+
+The system uses a robust dual verification approach to determine if a user has an active paid subscription:
+
+1. **Primary Method**: Checks the PaidSubscriber database table for the user's record and verifies that the current date is before the subscription expiration date.
+
+2. **Fallback Method**: If no database record is found, the system checks NIP-888 events for the user. It verifies that:
+   - The subscription tier is not a free tier
+   - The subscription has not expired (based on the expiration timestamp in the event)
+
+This dual approach ensures system resilience and graceful degradation if one verification method fails.
+
 ## Privacy and Security
 
 This implementation includes several security measures:
@@ -88,6 +146,8 @@ This implementation includes several security measures:
 3. **Local Processing**: Direct integration with Ollama LLM means all content filtering happens locally, so your data isn't sent to large cloud providers.
 
 4. **Optional Usage**: Filtering is fully opt-in. If you never send a kind 10010 event, nothing changes in your Nostr experience.
+
+5. **Resource Efficiency**: By limiting AI filtering to paid subscribers, we ensure the relay remains performant for all users.
 
 ## Configuration (For Relay Operators)
 
@@ -114,25 +174,33 @@ The following settings can be configured in `config.json`:
 ## Technical Details
 
 - Content filtering is only applied to kind 1 (text note) events for efficiency
-- Batch processing is used for efficient handling of multiple events:
+- Mute word filtering uses simple string matching for high performance and is available to all users
+- AI filtering (for paid subscribers with active subscriptions only):
+  - Subscription expiration is checked before applying AI filtering
+  - Batch processing is used for efficient handling of multiple events
   - Events are automatically grouped into batches when their count exceeds the threshold
   - Each batch is processed as a single API call, reducing HTTP overhead
   - If the batch API fails, the system gracefully falls back to individual processing
 - Intelligent caching minimizes API calls for previously seen events
 - Parallel processing ensures high throughput even with large event volumes
-- The implementation includes graceful degradation if the API is unavailable
+- The implementation includes graceful degradation if the AI service is unavailable
+- Subscription status is checked using both the PaidSubscriber table and NIP-888 events, with verification of expiration dates
 
 ## Colorized Logging
 
 The content filter implementation includes a colorized logging system that makes monitoring and debugging easier:
 
 ```
-[CONTENT FILTER] APPLYING FILTER FOR USER: pubkey...
+[CONTENT FILTER] APPLYING MUTE WORD FILTER FOR USER: pubkey...
+[CONTENT FILTER] USER pubkey IS A PAID SUBSCRIBER (VALID UNTIL 2025-05-15), APPLYING AI FILTERING
+[CONTENT FILTER] USER pubkey HAS EXPIRED PAID SUBSCRIPTION (EXPIRED ON 2025-03-01), SKIPPING AI FILTERING
 [CONTENT FILTER] EXEMPT EVENT: ID=abc123... (non-filterable event kind)
 [CONTENT FILTER] EVENT TO FILTER: ID=def456..., Content: "This is the content to filter..."
+[CONTENT FILTER] MUTED WORD: 'politics' found in event ID=ghi789...
 [CONTENT FILTER] OLLAMA RESPONSE: true
 [CONTENT FILTER] PASSED: ID=def456...
 [CONTENT FILTER] RESULTS: 2/7 filterable events passed filter, 1 exempt events
+[CONTENT FILTER] NON-PAID USER: Skipping AI filtering, 5 events passed mute filtering, 2 exempt events
 ```
 
 Color coding provides visual clarity in logs:

--- a/lib/handlers/nostr/contentfilter/service.go
+++ b/lib/handlers/nostr/contentfilter/service.go
@@ -71,7 +71,7 @@ func NewService(config ServiceConfig) *Service {
 		config.FilterKind = []int{1} // Default to only filtering kind 1 (text notes)
 	}
 	if config.Model == "" {
-		config.Model = "gemma3:4b" // Default model
+		config.Model = "gemma3:1b" // Default model - smaller and more efficient
 	}
 
 	return &Service{

--- a/lib/handlers/nostr/filter/filter.go
+++ b/lib/handlers/nostr/filter/filter.go
@@ -266,7 +266,11 @@ func BuildFilterHandler(store stores.Store) func(read lib_nostr.KindReader, writ
 				var nonFilterableEvents []*nostr.Event
 
 				for _, e := range uniqueEvents {
-					if filterService.ShouldFilterKind(e.Kind) {
+					if e.PubKey == connPubkey {
+						nonFilterableEvents = append(nonFilterableEvents, e)
+						log.Printf(ColorGreenBold+"[CONTENT FILTER] EXEMPT EVENT: ID=%s, Kind=%d, PubKey=%s (authored by requester)"+ColorReset,
+							e.ID, e.Kind, e.PubKey)
+					} else if filterService.ShouldFilterKind(e.Kind) {
 						filterableEvents = append(filterableEvents, e)
 					} else {
 						nonFilterableEvents = append(nonFilterableEvents, e)

--- a/lib/stores/badgerhold/badgerhold_moderation.go
+++ b/lib/stores/badgerhold/badgerhold_moderation.go
@@ -127,6 +127,12 @@ func (store *BadgerholdStore) IsEventBlocked(eventID string) (bool, error) {
 	return true, nil
 }
 
+// UnmarkEventBlocked removes an event from the blocked list
+func (store *BadgerholdStore) UnmarkEventBlocked(eventID string) error {
+	key := fmt.Sprintf("blocked:%s", eventID)
+	return store.Database.Delete(key, lib.BlockedEvent{})
+}
+
 // DeleteBlockedEventsOlderThan deletes events that have been blocked for longer than the specified age (in seconds)
 func (store *BadgerholdStore) DeleteBlockedEventsOlderThan(age int64) (int, error) {
 	var blockedEvents []lib.BlockedEvent

--- a/lib/stores/stores.go
+++ b/lib/stores/stores.go
@@ -39,6 +39,7 @@ type Store interface {
 	MarkEventBlocked(eventID string, timestamp int64) error
 	DeleteBlockedEventsOlderThan(age int64) (int, error)
 	IsEventBlocked(eventID string) (bool, error)
+	UnmarkEventBlocked(eventID string) error
 
 	// Pubkey Blocking
 	IsBlockedPubkey(pubkey string) (bool, error)

--- a/lib/types.go
+++ b/lib/types.go
@@ -232,6 +232,7 @@ type RelaySettings struct {
 	SubscriptionTiers   []SubscriptionTier `json:"subscription_tiers" mapstructure:"subscription_tiers"`
 	FreeTierEnabled     bool               `json:"freeTierEnabled" mapstructure:"freeTierEnabled"`
 	FreeTierLimit       string             `json:"freeTierLimit" mapstructure:"freeTierLimit"`
+	ModerationMode      string             `json:"moderationMode" mapstructure:"moderationMode"` // "strict" or "passive"
 	LastUpdated         int64              `json:"lastUpdated" mapstructure:"lastUpdated"`
 	MimeTypeGroups      map[string][]string
 	MimeTypeWhitelist   []string

--- a/lib/web/handler_moderation_notifications.go
+++ b/lib/web/handler_moderation_notifications.go
@@ -8,6 +8,7 @@ import (
 	"github.com/HORNET-Storage/hornet-storage/lib"
 	"github.com/HORNET-Storage/hornet-storage/lib/stores"
 	"github.com/gofiber/fiber/v2"
+	"github.com/nbd-wtf/go-nostr"
 )
 
 // GetModerationNotifications retrieves all moderation notifications with pagination
@@ -187,5 +188,125 @@ func createModerationNotification(c *fiber.Ctx, store stores.Store) error {
 		"success": true,
 		"message": "Notification created successfully",
 		"id":      notification.ID,
+	})
+}
+
+// GetBlockedEvent retrieves a blocked event by its ID
+func getBlockedEvent(c *fiber.Ctx, store stores.Store) error {
+	// Get event ID from the URL parameters
+	eventID := c.Params("id")
+	if eventID == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Event ID is required",
+		})
+	}
+
+	// Check if the event is actually blocked
+	isBlocked, err := store.IsEventBlocked(eventID)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to check event status: " + err.Error(),
+		})
+	}
+
+	if !isBlocked {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Event is not currently blocked",
+		})
+	}
+
+	// Query the event from the store
+	filter := nostr.Filter{
+		IDs: []string{eventID},
+	}
+	events, err := store.QueryEvents(filter)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to retrieve event: " + err.Error(),
+		})
+	}
+
+	if len(events) == 0 {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+			"error": "Event not found",
+		})
+	}
+
+	// Get the moderation notification for this event to include the reason
+	var notification *lib.ModerationNotification
+	notifications, _, err := store.GetStatsStore().GetAllModerationNotifications(1, 100)
+	if err == nil {
+		for _, n := range notifications {
+			if n.EventID == eventID {
+				notification = &n
+				break
+			}
+		}
+	}
+
+	log.Println("Blocked event: ", events[0])
+
+	// Return the event along with its moderation details
+	return c.JSON(fiber.Map{
+		"event":              events[0],
+		"moderation_details": notification,
+	})
+}
+
+// UnblockEvent handles requests to unblock incorrectly flagged content
+func unblockEvent(c *fiber.Ctx, store stores.Store) error {
+	// Get event ID from request body
+	var req struct {
+		EventID string `json:"event_id"`
+	}
+
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Invalid request body",
+		})
+	}
+
+	if req.EventID == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Event ID is required",
+		})
+	}
+
+	// Check if the event is actually blocked
+	isBlocked, err := store.IsEventBlocked(req.EventID)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to check event status: " + err.Error(),
+		})
+	}
+
+	if !isBlocked {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Event is not currently blocked",
+		})
+	}
+
+	// Unblock the event
+	if err := store.UnmarkEventBlocked(req.EventID); err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to unblock event: " + err.Error(),
+		})
+	}
+
+	// Find and delete the corresponding moderation notification
+	notifications, _, err := store.GetStatsStore().GetAllModerationNotifications(1, 100)
+	if err == nil {
+		for _, notification := range notifications {
+			if notification.EventID == req.EventID {
+				store.GetStatsStore().DeleteModerationNotification(notification.ID)
+				break
+			}
+		}
+	}
+
+	return c.JSON(fiber.Map{
+		"success":  true,
+		"message":  "Event unblocked successfully",
+		"event_id": req.EventID,
 	})
 }

--- a/lib/web/handler_relay_settings.go
+++ b/lib/web/handler_relay_settings.go
@@ -151,6 +151,11 @@ func getRelaySettings(c *fiber.Ctx) error {
 		relaySettings.FreeTierLimit = "100 MB per month"
 	}
 
+	// Initialize moderation mode if not set
+	if relaySettings.ModerationMode == "" {
+		relaySettings.ModerationMode = "strict" // Default to strict mode
+	}
+
 	log.Printf("Fetched relay settings: %+v", relaySettings) // Using %+v for more detailed output
 
 	return c.JSON(fiber.Map{

--- a/lib/web/server.go
+++ b/lib/web/server.go
@@ -151,6 +151,12 @@ func StartServer(store stores.Store) error {
 	secured.Post("/moderation/notifications", func(c *fiber.Ctx) error {
 		return createModerationNotification(c, store)
 	})
+	secured.Get("/moderation/blocked-event/:id", func(c *fiber.Ctx) error {
+		return getBlockedEvent(c, store)
+	})
+	secured.Post("/moderation/unblock", func(c *fiber.Ctx) error {
+		return unblockEvent(c, store)
+	})
 
 	// Payment notification routes
 	secured.Get("/payment/notifications", func(c *fiber.Ctx) error {

--- a/lib/web/server.go
+++ b/lib/web/server.go
@@ -157,6 +157,9 @@ func StartServer(store stores.Store) error {
 	secured.Post("/moderation/unblock", func(c *fiber.Ctx) error {
 		return unblockEvent(c, store)
 	})
+	secured.Delete("/moderation/event/:id", func(c *fiber.Ctx) error {
+		return deleteModeratedEvent(c, store)
+	})
 
 	// Payment notification routes
 	secured.Get("/payment/notifications", func(c *fiber.Ctx) error {

--- a/services/server/port/main.go
+++ b/services/server/port/main.go
@@ -160,6 +160,9 @@ func init() {
 	viper.SetDefault("image_moderation_timeout", 60)        // seconds
 	viper.SetDefault("image_moderation_concurrency", 5)
 
+	// Moderation mode for event visibility during moderation
+	viper.SetDefault("moderation_mode", "strict") // Options: "strict" or "passive"
+
 	viper.AddConfigPath(".")
 	viper.SetConfigType("json")
 

--- a/services/server/port/main.go
+++ b/services/server/port/main.go
@@ -115,6 +115,7 @@ func init() {
 		"KindWhitelist":    []string{"kind0", "kind1", "kind22242", "kind10010"}, // Essential kinds always enabled
 		"FreeTierEnabled":  true,
 		"FreeTierLimit":    "100 MB per month",
+		"ModerationMode":   "strict", // Default moderation mode to "strict"
 		"subscription_tiers": []map[string]interface{}{
 			{
 				"DataLimit": "1 GB per month",
@@ -160,8 +161,7 @@ func init() {
 	viper.SetDefault("image_moderation_timeout", 60)        // seconds
 	viper.SetDefault("image_moderation_concurrency", 5)
 
-	// Moderation mode for event visibility during moderation
-	viper.SetDefault("moderation_mode", "strict") // Options: "strict" or "passive"
+	// We no longer need to set the top-level moderation_mode as we're using the one in relay_settings
 
 	viper.AddConfigPath(".")
 	viper.SetConfigType("json")


### PR DESCRIPTION
# Improve kind10010 Structure Using Nostr Tags Convention

## Summary
This PR refactors the kind10010 (content filtering preferences) structure to better align with Nostr conventions by using tags for metadata instead of embedding everything in the content JSON.

## Changes

### New Structure
- **Content Field**: Contains only the filtering instructions as plain text
- **Tags**:
  - `["enabled", "true/false"]`: Boolean flag indicating if filtering is enabled
  - `["mute", "word1,word2,word3"]`: Comma-separated list of words to mute

### Implementation Details
- Modified `FilterPreference` struct to include MuteWords array
- Updated `BuildKind10010Handler` to parse tags instead of JSON content
- Enhanced `GetUserFilterPreference` to extract data from tags
- Improved filtering logic in filter.go to support:
  1. First filtering out events containing muted words
  2. Then applying instruction-based filtering if instructions exist

### Benefits
- Better alignment with Nostr conventions (metadata in tags)
- Support for both instruction-based and simple word-based filtering
- Cleaner separation between instructions and metadata
- More efficient processing

## Testing
- Verified that the backend correctly processes events with the new structure
- Confirmed frontend integration works correctly
- Tested all three filtering scenarios:
  1. Using only instructions
  2. Using only mute words
  3. Using both instructions and mute words

## Frontend Integration
The frontend has been updated to create kind10010 events with the new structure, with instructions in the content field and metadata in tags.