### PR TITLE
fix: Update wallet name config references to use correct path

### DIFF
--- a/lib/web/handlers/wallet/handler_wallet_addresses.go
+++ b/lib/web/handlers/wallet/handler_wallet_addresses.go
@@ -45,7 +45,7 @@ func SaveWalletAddresses(c *fiber.Ctx, store stores.Store) error {
 		addresses = append(addresses, addr)
 	}
 
-	expectedWalletName := viper.GetString("wallet_name")
+	expectedWalletName := viper.GetString("wallet.name")
 	if expectedWalletName == "" {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "Wallet name not configured"})
 	}

--- a/lib/web/handlers/wallet/handler_wallet_balance.go
+++ b/lib/web/handlers/wallet/handler_wallet_balance.go
@@ -81,11 +81,11 @@ func UpdateWalletBalance(c *fiber.Ctx, store stores.Store) error {
 	}
 
 	// Get the configured wallet name, if it's empty use the one from the request
-	expectedWalletName := viper.GetString("wallet_name")
+	expectedWalletName := viper.GetString("wallet.name")
 	if expectedWalletName == "" {
 		log.Printf("No wallet name configured, using wallet name from request: %s", walletName)
 		// Update the config with the wallet name from the request
-		viper.Set("wallet_name", walletName)
+		viper.Set("wallet.name", walletName)
 		if err := viper.WriteConfig(); err != nil {
 			log.Printf("Warning: Failed to write wallet name to config: %v", err)
 			// Continue processing even if writing to config fails

--- a/lib/web/handlers/wallet/utils.go
+++ b/lib/web/handlers/wallet/utils.go
@@ -67,12 +67,12 @@ func ExtractTransactionDetails(transaction map[string]interface{}) (*transaction
 
 // validateWalletName ensures the wallet name is valid and consistent
 func ValidateWalletName(transactions []map[string]interface{}) string {
-	expectedWalletName := viper.GetString("wallet_name")
+	expectedWalletName := viper.GetString("wallet.name")
 
 	// Set wallet name from first transaction if not set
 	if expectedWalletName == "" && len(transactions) > 0 {
 		if walletName, ok := transactions[0]["wallet_name"].(string); ok {
-			viper.Set("wallet_name", walletName)
+			viper.Set("wallet.name", walletName)
 			expectedWalletName = walletName
 		}
 	}


### PR DESCRIPTION
Change wallet handlers to use 'wallet.name' instead of 'wallet_name' in Viper config calls to match the actual config structure.