### PR TITLE
Feature/invite only tier updates

### DIFF
--- a/docs/NIP-888-Implementation.md
+++ b/docs/NIP-888-Implementation.md
@@ -65,14 +65,14 @@ The kind 411 nostr note structure would be as follows:
 }
 ```
 
-When a user first connects to the relay and authenticates, the system automatically initializes a subscription record by creating a kind 888 note specifically for that user. This occurs during the initialization process and before any tier selection or payment. The kind 888 event includes a unique Bitcoin address assigned to the user for payment tracking:
+When a user first connects to the relay and authenticates, the system automatically initializes a subscription record by creating a kind 11888 note specifically for that user. This occurs during the initialization process and before any tier selection or payment. The kind 11888 event includes a unique Bitcoin address assigned to the user for payment tracking:
 
 ```json
 {
   "id": "<unique_note_id>",
   "pubkey": "<relay_public_key_hex>",
   "created_at": <timestamp>,
-  "kind": 888,
+  "kind": 11888,
   "tags": [
     ["subscription_duration", "1 month"],
     ["p", "<user_pubkey_hex>"],
@@ -86,7 +86,7 @@ When a user first connects to the relay and authenticates, the system automatica
 }
 ```
 
-This initial kind 888 event serves as a subscription record that will track the user's status, allocated storage, payment history, and credit. If the relay doesn't offer a public tier, the event starts with "inactive" status and zero storage allocation until a payment is received. However, if the relay has configured a public tier, the user's subscription would start with "active" status and would be allocated the storage amount specified in the public tier configuration, without requiring any payment.
+This initial kind 11888 event serves as a subscription record that will track the user's status, allocated storage, payment history, and credit. If the relay doesn't offer a public tier, the event starts with "inactive" status and zero storage allocation until a payment is received. However, if the relay has configured a public tier, the user's subscription would start with "active" status and would be allocated the storage amount specified in the public tier configuration, without requiring any payment.
 
 ### Step 5: Enhanced User Payment Process
 
@@ -110,14 +110,14 @@ For example, if a user pays 85,000 sats with tier prices of 70,000, 40,000, and 
 #### c) Credit Accumulation and Auto-Application
 For payments smaller than any tier price, or for remainders after tier purchases, the system stores the amount as credit. When accumulated credit reaches a tier threshold, it's automatically applied to purchase additional storage.
 
-The updated kind 888 event includes credit information:
+The updated kind 11888 event includes credit information:
 
 ```json
 {
   "id": "<unique_note_id>",
   "pubkey": "<relay_public_key_hex>",
   "created_at": <timestamp>,
-  "kind": 888,
+  "kind": 11888,
   "tags": [
     ["subscription_duration", "1 month"],
     ["p", "<user_pubkey_hex>"],
@@ -153,7 +153,7 @@ Upon receiving a Bitcoin payment, the relay performs several operations:
 4. **Subscription Record Update**:
    - The subscription's expiration date is updated based on the periods purchased
    - For multi-period purchases, the expiration is extended accordingly
-   - All changes are recorded in an updated kind 888 event
+   - All changes are recorded in an updated kind 11888 event
 
 ## Credit Management System
 
@@ -174,14 +174,14 @@ The system continually evaluates accumulated credit:
 5. This process happens recursively until no more tiers can be purchased
 
 ### Credit Visibility in NIP-888 Events
-Credit information is always included in the user's kind 888 event, providing transparency:
+Credit information is always included in the user's kind 11888 event, providing transparency:
 - A `credit` tag displays the current credit amount in satoshis
 - This tag is updated after every transaction or credit application
 - The credit is visible to other relays and clients that may need this information
 
 ## Unlimited Storage Support
 
-For certain relay configurations (such as only-me mode or invite-only users), unlimited storage may be granted. This is indicated in the kind 888 event by using "unlimited" as the total bytes value in the storage tag:
+For certain relay configurations (such as only-me mode or invite-only users), unlimited storage may be granted. This is indicated in the kind 11888 event by using "unlimited" as the total bytes value in the storage tag:
 
 ### Standard Storage Tag
 ```json
@@ -249,16 +249,16 @@ The kind 411 nostr note structure would be as follows:
 
 ### Step 5: User Selection and Event Signing
 
-The user reviews the available subscription tiers and selects their desired tier by creating and signing a kind 888 nostr event. This event specifies the chosen subscription tier and includes the user's pubkey (in hex format) along with other necessary information. The relay's DHT key is included to identify the relay the user is subscribing to. Once signed, this event is sent to the relay.
+The user reviews the available subscription tiers and selects their desired tier by creating and signing a kind 11888 nostr event. This event specifies the chosen subscription tier and includes the user's pubkey (in hex format) along with other necessary information. The relay's DHT key is included to identify the relay the user is subscribing to. Once signed, this event is sent to the relay.
 
-The kind 888 nostr event structure would be as follows:
+The kind 11888 nostr event structure would be as follows:
 
 ```json
 {
   "id": "<unique_note_id>",
   "pubkey": "<user_pubkey_hex>",
   "created_at": <timestamp>,
-  "kind": 888,
+  "kind": 11888,
   "tags": [
     ["subscription-tier", "5 GB per month", "40000"],
     ["subscription-duration", "1 month"],
@@ -271,7 +271,7 @@ The kind 888 nostr event structure would be as follows:
 
 ### Step 6: Generating the Lightning Invoice
 
-Upon receiving the signed kind 888 event, the relay generates a Lightning Network (LN) invoice corresponding to the selected tier's price. The invoice is dynamically created based on the user's choice and is sent back to the user through the relay.
+Upon receiving the signed kind 11888 event, the relay generates a Lightning Network (LN) invoice corresponding to the selected tier's price. The invoice is dynamically created based on the user's choice and is sent back to the user through the relay.
 
 ### Step 7: User Payment Process for Lightning Network Transactions
 

--- a/docs/NIP-888-Implementation.md
+++ b/docs/NIP-888-Implementation.md
@@ -33,18 +33,18 @@ Upon connecting to the new relay, the user's client automatically sends a NIP42 
 
 ### Step 4: Displaying and Selecting a Subscription Plan
 
-Once the authentication is successful, the relay presents the user with available subscription options by issuing a kind 411 nostr note (previously referred to as kind 88 in early implementations). Each subscription tier is listed in the content section of the note, providing details on the data limit and the corresponding price.
+Once the authentication is successful, the relay presents the user with available subscription options by issuing a kind 10411 nostr note (previously referred to as kind 88 in early implementations). Each subscription tier is listed in the content section of the note, providing details on the data limit and the corresponding price.
 
 To facilitate payment tracking and automatic user registration, the relay generates a unique Bitcoin address for each user. This unique address is specifically tied to the user's payment and is crucial for correlating the payment with the specific user in the backend system.
 
-The kind 411 nostr note structure would be as follows:
+The kind 10411 nostr note structure would be as follows:
 
 ```json
 {
   "id": "<unique_note_id>",
   "pubkey": "<relay_public_key_hex>",
   "created_at": <timestamp>,
-  "kind": 411,
+  "kind": 10411,
   "tags": [],
   "content": {
     "name": "Relay Name",
@@ -217,16 +217,16 @@ Upon connecting to the new relay, the user's client automatically sends a NIP42 
 
 ### Step 4: Displaying Subscription Plans
 
-Once the authentication is successful, the relay presents the user with available subscription options by issuing a kind 411 nostr note. Each subscription tier is listed in the content section, providing details on the data limit and the corresponding price.
+Once the authentication is successful, the relay presents the user with available subscription options by issuing a kind 10411 nostr note. Each subscription tier is listed in the content section, providing details on the data limit and the corresponding price.
 
-The kind 411 nostr note structure would be as follows:
+The kind 10411 nostr note structure would be as follows:
 
 ```json
 {
   "id": "<unique_note_id>",
   "pubkey": "<relay_public_key_hex>",
   "created_at": <timestamp>,
-  "kind": 411,
+  "kind": 10411,
   "tags": [],
   "content": {
     "name": "Relay Name",

--- a/docs/Subscription-System.md
+++ b/docs/Subscription-System.md
@@ -1,8 +1,8 @@
-# Kind 888 Multi-Mode Relay System
+# Kind 11888 Multi-Mode Relay System
 
 ## Overview
 
-Kind 888 events serve as the subscription and storage management system for the HORNETS Nostr relay. This system handles four distinct relay modes and provides clients with comprehensive information about user storage allocations, subscription status, and payment requirements.
+Kind 11888 events serve as the subscription and storage management system for the HORNETS Nostr relay. This system handles four distinct relay modes and provides clients with comprehensive information about user storage allocations, subscription status, and payment requirements.
 
 ## Relay Modes
 
@@ -34,11 +34,11 @@ Kind 888 events serve as the subscription and storage management system for the 
 - **Storage Policy**: No limits
 - **UI Behavior**: Simple storage usage display
 
-## Kind 888 Event Structure
+## Kind 11888 Event Structure
 
 ```json
 {
-  "kind": 888,
+  "kind": 11888,
   "pubkey": "<relay_public_key>",
   "created_at": <timestamp>,
   "tags": [
@@ -107,13 +107,13 @@ Kind 888 events serve as the subscription and storage management system for the 
 ### Credit Application
 - Credit automatically applied on next payment
 - Credit used to purchase additional storage when threshold reached
-- Visible in kind 888 events for transparency
+- Visible in kind 11888 events for transparency
 
 ## Client Integration Guidelines
 
 ### Reading relay_mode Tag
 ```javascript
-function parseKind888Event(event) {
+function parseKind11888Event(event) {
   const relayMode = getTagValue(event.tags, 'relay_mode');
   const storage = getTagValues(event.tags, 'storage');
   const isUnlimited = storage[1] === 'unlimited';
@@ -150,7 +150,7 @@ function getStorageDisplayText(storage) {
 When relay operators change modes, the system:
 
 1. **Preserves existing subscriptions** until natural expiration
-2. **Updates new kind 888 events** with current mode
+2. **Updates new kind 11888 events** with current mode
 3. **Batch updates existing events** to include relay_mode tag
 4. **Maintains storage allocations** during transition period
 
@@ -172,7 +172,7 @@ When relay operators change modes, the system:
 ### Update Process
 1. Calculate storage delta for operation
 2. Check against current limits
-3. Update kind 888 event with new usage
+3. Update kind 11888 event with new usage
 4. Enforce limits if exceeded
 
 ## Backend Implementation Notes
@@ -183,7 +183,7 @@ When relay operators change modes, the system:
 - Default to "unknown" if config unavailable
 
 ### Event Creation
-- All kind 888 events automatically include relay_mode tag
+- All kind 11888 events automatically include relay_mode tag
 - Mode read fresh from config on each event creation
 - Ensures consistency even during mode transitions
 
@@ -195,7 +195,7 @@ When relay operators change modes, the system:
 ## Migration and Compatibility
 
 ### Existing Events
-- Old kind 888 events without relay_mode tag remain valid
+- Old kind 11888 events without relay_mode tag remain valid
 - Batch update process adds relay_mode to existing events
 - Backward compatibility maintained for clients
 
@@ -209,7 +209,7 @@ When relay operators change modes, the system:
 ### Log Messages
 - Mode loading: `"[DEBUG] Creating storage info for npub X: mode=Y"`
 - Event creation: `"Creating/updating NIP-88 event for X with tier Y"`
-- Storage updates: `"[DEBUG] Creating kind 888 event: totalBytes=X"`
+- Storage updates: `"[DEBUG] Creating kind 11888 event: totalBytes=X"`
 
 ### Common Issues
 - "Unknown mode" logs indicate config loading problems

--- a/lib/handlers/nostr/filter/filter.go
+++ b/lib/handlers/nostr/filter/filter.go
@@ -150,13 +150,13 @@ func BuildFilterHandler(store stores.Store) func(read lib_nostr.KindReader, writ
 			}
 		}
 
-		// Initialize subscription manager if needed for kind 888 events
+		// Initialize subscription manager if needed for kind 11888 events
 		var subManager *subscription.SubscriptionManager
-		// Check if any filter is requesting kind 888 events
+		// Check if any filter is requesting kind 11888 events
 		needsSubscriptionManager := false
 		for _, filter := range request.Filters {
 			for _, kind := range filter.Kinds {
-				if kind == 888 {
+				if kind == 11888 {
 					needsSubscriptionManager = true
 					break
 				}
@@ -502,41 +502,41 @@ func BuildFilterHandler(store stores.Store) func(read lib_nostr.KindReader, writ
 				}
 			}
 
-			// Special handling for kind 888 events
-			if event.Kind == 888 {
-				log.Printf("Processing kind 888 event with ID: %s", event.ID)
+			// Special handling for kind 11888 events
+			if event.Kind == 11888 {
+				log.Printf("Processing kind 11888 event with ID: %s", event.ID)
 
 				// Extract the pubkey the event is about (from the p tag)
 				eventPubkey := ""
 				for _, tag := range event.Tags {
 					if tag[0] == "p" && len(tag) > 1 {
 						eventPubkey = tag[1]
-						log.Printf("Kind 888 event is about pubkey: %s", eventPubkey)
+						log.Printf("Kind 11888 event is about pubkey: %s", eventPubkey)
 						break
 					}
 				}
 
 				// Log the auth and authorization check
-				log.Printf("Auth check for kind 888: event pubkey=%s, connection pubkey=%s",
+				log.Printf("Auth check for kind 11888: event pubkey=%s, connection pubkey=%s",
 					eventPubkey, connPubkey)
 
 				// If the pubkey in the event is not empty and doesn't match the authenticated user
 				if eventPubkey != "" && connPubkey != "" && eventPubkey != connPubkey {
 					// Skip this event - user is not authorized to see subscription details for other users
-					log.Printf("DENIED: Skipping kind 888 event for pubkey %s - requested by different pubkey %s",
+					log.Printf("DENIED: Skipping kind 11888 event for pubkey %s - requested by different pubkey %s",
 						eventPubkey, connPubkey)
 					continue
 				} else {
-					log.Printf("ALLOWED: Showing kind 888 event for pubkey %s to connection with pubkey %s",
+					log.Printf("ALLOWED: Showing kind 11888 event for pubkey %s to connection with pubkey %s",
 						eventPubkey, connPubkey)
 				}
 
 				// Only update if we have a subscription manager
 				if subManager != nil {
-					log.Printf("Checking if kind 888 event needs update...")
+					log.Printf("Checking if kind 11888 event needs update...")
 					updatedEvent, err := subManager.CheckAndUpdateSubscriptionEvent(event)
 					if err != nil {
-						log.Printf("Error updating kind 888 event: %v", err)
+						log.Printf("Error updating kind 11888 event: %v", err)
 					} else if updatedEvent != event {
 						log.Printf("Event was updated with new information")
 						event = updatedEvent

--- a/lib/handlers/nostr/kind10411/subscriptionEventsCreator.go
+++ b/lib/handlers/nostr/kind10411/subscriptionEventsCreator.go
@@ -1,4 +1,4 @@
-package kind411
+package kind10411
 
 import (
 	"crypto/sha256"
@@ -60,7 +60,7 @@ func formatDataLimit(bytes int64, unlimited bool) string {
 	return fmt.Sprintf("%d MB per month", bytes/MB)
 }
 
-func CreateKind411Event(privateKey *secp256k1.PrivateKey, publicKey *secp256k1.PublicKey, store stores.Store) error {
+func CreateKind10411Event(privateKey *secp256k1.PrivateKey, publicKey *secp256k1.PublicKey, store stores.Store) error {
 	// Get subscription tiers from allowed_users.tiers
 	var allTiers []types.SubscriptionTier
 	if err := viper.UnmarshalKey("allowed_users.tiers", &allTiers); err != nil {
@@ -87,22 +87,22 @@ func CreateKind411Event(privateKey *secp256k1.PrivateKey, publicKey *secp256k1.P
 		})
 	}
 
-	log.Println("Paid Tiers for kind 411:", tiers)
+	log.Println("Paid Tiers for kind 10411:", tiers)
 
-	// Delete existing kind 411 events
+	// Delete existing kind 10411 events
 	filter := nostr.Filter{
-		Kinds: []int{411},
+		Kinds: []int{10411},
 	}
 	existingEvents, err := store.QueryEvents(filter)
 	if err != nil {
-		return fmt.Errorf("error querying existing kind 411 events: %v", err)
+		return fmt.Errorf("error querying existing kind 10411 events: %v", err)
 	}
 
 	for _, oldEvent := range existingEvents {
 		if err := store.DeleteEvent(oldEvent.ID); err != nil {
-			return fmt.Errorf("error deleting old kind 411 event %s: %v", oldEvent.ID, err)
+			return fmt.Errorf("error deleting old kind 10411 event %s: %v", oldEvent.ID, err)
 		}
-		log.Printf("Deleted existing kind 411 event with ID: %s", oldEvent.ID)
+		log.Printf("Deleted existing kind 10411 event with ID: %s", oldEvent.ID)
 	}
 
 	// Convert tiers to the expected format
@@ -134,14 +134,14 @@ func CreateKind411Event(privateKey *secp256k1.PrivateKey, publicKey *secp256k1.P
 	}
 
 	// Create the event
-	event, err := createAnyEvent(privateKey, publicKey, 411, string(content), []nostr.Tag{})
+	event, err := createAnyEvent(privateKey, publicKey, 10411, string(content), []nostr.Tag{})
 	if err != nil {
-		return fmt.Errorf("error creating kind 411 event: %v", err)
+		return fmt.Errorf("error creating kind 10411 event: %v", err)
 	}
 
 	// Store the new event
 	if err := store.StoreEvent(event); err != nil {
-		return fmt.Errorf("error storing kind 411 event: %v", err)
+		return fmt.Errorf("error storing kind 10411 event: %v", err)
 	}
 
 	// Print the event for verification
@@ -149,10 +149,10 @@ func CreateKind411Event(privateKey *secp256k1.PrivateKey, publicKey *secp256k1.P
 	if err != nil {
 		log.Printf("Error marshaling event for printing: %v", err)
 	} else {
-		log.Printf("Created and stored kind 411 event:\n%s", string(eventJSON))
+		log.Printf("Created and stored kind 10411 event:\n%s", string(eventJSON))
 	}
 
-	log.Println("Kind 411 event created and stored successfully")
+	log.Println("Kind 10411 event created and stored successfully")
 	return nil
 }
 

--- a/lib/stores/statistics/gorm/statistics_gorm.go
+++ b/lib/stores/statistics/gorm/statistics_gorm.go
@@ -1789,13 +1789,13 @@ func (store *GormStatisticsStore) DeletePaidSubscriber(npub string) error {
 
 // NPUB access control management implementation
 func (store *GormStatisticsStore) GetAllowedUser(npub string) (*types.AllowedUser, error) {
-	var user *types.AllowedUser
-	err := store.DB.Model(&types.AllowedUser{}).First(user, "npub = ?", npub).Error
+	var user types.AllowedUser
+	err := store.DB.Model(&types.AllowedUser{}).Where("npub = ?", npub).First(&user).Error
 	if err != nil {
 		return nil, err
 	}
 
-	return user, nil
+	return &user, nil
 }
 
 func (store *GormStatisticsStore) AddAllowedUser(npub string, tier string, createdBy string) error {

--- a/lib/subscription/batch.go
+++ b/lib/subscription/batch.go
@@ -14,7 +14,7 @@ import (
 	"github.com/HORNET-Storage/hornet-storage/lib/types"
 )
 
-// ScheduleBatchUpdateAfter schedules a batch update of all kind 888 events after
+// ScheduleBatchUpdateAfter schedules a batch update of all kind 11888 events after
 // the specified delay. If called multiple times, it cancels any previous scheduled update
 // and restarts the timer with a new delay (sliding window approach).
 func ScheduleBatchUpdateAfter(delay time.Duration) {
@@ -24,9 +24,9 @@ func ScheduleBatchUpdateAfter(delay time.Duration) {
 	// Cancel any existing scheduled update
 	if scheduledUpdateTimer != nil {
 		scheduledUpdateTimer.Stop()
-		log.Printf("Rescheduling batch update of kind 888 events (settings changed again)")
+		log.Printf("Rescheduling batch update of kind 11888 events (settings changed again)")
 	} else {
-		log.Printf("Scheduling batch update of kind 888 events in %v", delay)
+		log.Printf("Scheduling batch update of kind 11888 events in %v", delay)
 	}
 
 	// Schedule new update
@@ -35,22 +35,22 @@ func ScheduleBatchUpdateAfter(delay time.Duration) {
 		scheduledUpdateTimer = nil
 		scheduledUpdateMutex.Unlock()
 
-		log.Printf("Starting batch update of kind 888 events after %v cooldown", delay)
+		log.Printf("Starting batch update of kind 11888 events after %v cooldown", delay)
 		manager := GetGlobalManager()
 		if manager != nil {
 			if err := manager.BatchUpdateAllSubscriptionEvents(); err != nil {
 				log.Printf("Error in batch update: %v", err)
 			} else {
-				log.Printf("Successfully completed batch update of kind 888 events")
+				log.Printf("Successfully completed batch update of kind 11888 events")
 			}
 		}
 	})
 }
 
-// BatchUpdateAllSubscriptionEvents processes all kind 888 events in batches
+// BatchUpdateAllSubscriptionEvents processes all kind 11888 events in batches
 // to update storage allocations after allowed users settings have changed
 func (m *SubscriptionManager) BatchUpdateAllSubscriptionEvents() error {
-	log.Printf("Starting batch update of all kind 888 subscription events")
+	log.Printf("Starting batch update of all kind 11888 subscription events")
 
 	// Get the current allowed users settings
 	var allowedUsersSettings types.AllowedUsersSettings
@@ -65,7 +65,7 @@ func (m *SubscriptionManager) BatchUpdateAllSubscriptionEvents() error {
 	for {
 		// Query the next batch of events
 		filter := nostr.Filter{
-			Kinds: []int{888},
+			Kinds: []int{11888},
 			Limit: batchSize,
 		}
 
@@ -89,7 +89,7 @@ func (m *SubscriptionManager) BatchUpdateAllSubscriptionEvents() error {
 			processed++
 		}
 
-		log.Printf("Processed %d kind 888 events so far", processed)
+		log.Printf("Processed %d kind 11888 events so far", processed)
 
 		// If we received fewer events than requested, we've reached the end of available events
 		if len(events) < batchSize {
@@ -97,7 +97,7 @@ func (m *SubscriptionManager) BatchUpdateAllSubscriptionEvents() error {
 		}
 	}
 
-	log.Printf("Completed batch update, processed %d kind 888 events", processed)
+	log.Printf("Completed batch update, processed %d kind 11888 events", processed)
 
 	// If we're in subscription mode, also allocate Bitcoin addresses for users who don't have them
 	if allowedUsersSettings.Mode == "subscription" {
@@ -111,7 +111,7 @@ func (m *SubscriptionManager) BatchUpdateAllSubscriptionEvents() error {
 	return nil
 }
 
-// processSingleSubscriptionEvent handles updating relay_mode tag and storage limits for existing kind 888 events
+// processSingleSubscriptionEvent handles updating relay_mode tag and storage limits for existing kind 11888 events
 func (m *SubscriptionManager) processSingleSubscriptionEvent(event *nostr.Event) error {
 	// Extract pubkey
 	pubkey := getTagValue(event.Tags, "p")
@@ -203,16 +203,16 @@ func (m *SubscriptionManager) processSingleSubscriptionEvent(event *nostr.Event)
 func (m *SubscriptionManager) AllocateBitcoinAddressesForExistingUsers() error {
 	log.Printf("Starting batch Bitcoin address allocation for existing users")
 
-	// Query all kind 888 events first
+	// Query all kind 11888 events first
 	allEvents, err := m.store.QueryEvents(nostr.Filter{
-		Kinds: []int{888},
+		Kinds: []int{11888},
 	})
 
 	if err != nil {
 		return fmt.Errorf("failed to query events: %v", err)
 	}
 
-	log.Printf("Found %d total kind 888 events, checking for empty Bitcoin addresses", len(allEvents))
+	log.Printf("Found %d total kind 11888 events, checking for empty Bitcoin addresses", len(allEvents))
 
 	// Filter events that have empty Bitcoin addresses
 	var eventsNeedingAddresses []*nostr.Event
@@ -254,9 +254,9 @@ func (m *SubscriptionManager) AllocateBitcoinAddressesForExistingUsers() error {
 			continue
 		}
 
-		// Update the kind 888 event with the new address
+		// Update the kind 11888 event with the new address
 		if err := m.updateEventWithBitcoinAddress(event, addressObj.Address); err != nil {
-			log.Printf("Failed to update kind 888 event for %s: %v", pubkey, err)
+			log.Printf("Failed to update kind 11888 event for %s: %v", pubkey, err)
 			continue
 		}
 
@@ -268,7 +268,7 @@ func (m *SubscriptionManager) AllocateBitcoinAddressesForExistingUsers() error {
 	return nil
 }
 
-// updateEventWithBitcoinAddress updates an existing kind 888 event to include a Bitcoin address
+// updateEventWithBitcoinAddress updates an existing kind 11888 event to include a Bitcoin address
 func (m *SubscriptionManager) updateEventWithBitcoinAddress(originalEvent *nostr.Event, bitcoinAddress string) error {
 	// Extract current event data
 	pubkey := getTagValue(originalEvent.Tags, "p")

--- a/lib/subscription/events.go
+++ b/lib/subscription/events.go
@@ -1,4 +1,4 @@
-// events.go - Kind 888 event management
+// events.go - Kind 11888 event management
 
 package subscription
 
@@ -44,7 +44,7 @@ func (m *SubscriptionManager) createEvent(
 		return fmt.Sprintf("%d", storageInfo.TotalBytes)
 	}()
 
-	log.Printf("[DEBUG] Creating kind 888 event for %s: usedBytes=%d, totalBytes=%s, isUnlimited=%t",
+	log.Printf("[DEBUG] Creating kind 11888 event for %s: usedBytes=%d, totalBytes=%s, isUnlimited=%t",
 		subscriber.Npub, storageInfo.UsedBytes, totalBytesStr, storageInfo.IsUnlimited)
 
 	// Get relay mode from config
@@ -63,9 +63,9 @@ func (m *SubscriptionManager) createEvent(
 
 	// Log address handling for debugging
 	if subscriber.Address == "" {
-		log.Printf("Creating kind 888 event without Bitcoin address for user %s", subscriber.Npub)
+		log.Printf("Creating kind 11888 event without Bitcoin address for user %s", subscriber.Npub)
 	} else {
-		log.Printf("Creating kind 888 event with Bitcoin address %s for user %s", subscriber.Address, subscriber.Npub)
+		log.Printf("Creating kind 11888 event with Bitcoin address %s for user %s", subscriber.Address, subscriber.Npub)
 	}
 
 	// Add credit information if there is any
@@ -88,7 +88,7 @@ func (m *SubscriptionManager) createEvent(
 	event := &nostr.Event{
 		PubKey:    hex.EncodeToString(m.relayPrivateKey.PubKey().SerializeCompressed()),
 		CreatedAt: nostr.Timestamp(time.Now().Unix()),
-		Kind:      888,
+		Kind:      11888,
 		Tags:      tags,
 		Content:   "",
 	}
@@ -132,7 +132,7 @@ func (m *SubscriptionManager) createOrUpdateNIP88Event(
 	}
 
 	existingEvents, err := m.store.QueryEvents(nostr.Filter{
-		Kinds: []int{888},
+		Kinds: []int{11888},
 		Tags: nostr.TagMap{
 			"p": []string{npub, hex}, // Check both formats
 		},
@@ -167,7 +167,7 @@ func (m *SubscriptionManager) createNIP88EventIfNotExists(
 
 	// Check for existing event
 	existingEvents, err := m.store.QueryEvents(nostr.Filter{
-		Kinds: []int{888},
+		Kinds: []int{11888},
 		Tags: nostr.TagMap{
 			"p": []string{subscriber.Npub},
 		},
@@ -201,7 +201,7 @@ func (m *SubscriptionManager) createNIP88EventIfNotExists(
 
 	// Verification
 	storedEvents, err := m.store.QueryEvents(nostr.Filter{
-		Kinds: []int{888},
+		Kinds: []int{11888},
 		Tags: nostr.TagMap{
 			"p": []string{subscriber.Npub},
 		},

--- a/lib/subscription/free_tier.go
+++ b/lib/subscription/free_tier.go
@@ -64,9 +64,9 @@ func (m *SubscriptionManager) RefreshExpiredFreeTierSubscriptions() error {
 	refreshed := 0
 
 	for {
-		// Query all kind 888 events in batches
+		// Query all kind 11888 events in batches
 		filter := nostr.Filter{
-			Kinds: []int{888},
+			Kinds: []int{11888},
 			Limit: batchSize,
 		}
 

--- a/lib/subscription/payment.go
+++ b/lib/subscription/payment.go
@@ -83,7 +83,7 @@ func (m *SubscriptionManager) ProcessPayment(
 
 			// Update the NIP-88 event to reflect the new credit amount
 			events, err := m.store.QueryEvents(nostr.Filter{
-				Kinds: []int{888},
+				Kinds: []int{11888},
 				Tags:  nostr.TagMap{"p": []string{npub}},
 				Limit: 1,
 			})
@@ -137,7 +137,7 @@ func (m *SubscriptionManager) ProcessPayment(
 
 	// Fetch current NIP-88 event to get existing state
 	events, err := m.store.QueryEvents(nostr.Filter{
-		Kinds: []int{888},
+		Kinds: []int{11888},
 		Tags:  nostr.TagMap{"p": []string{npub}},
 		Limit: 1,
 	})
@@ -208,7 +208,7 @@ func (m *SubscriptionManager) ProcessPayment(
 
 	// Verify the update
 	updatedEvents, err := m.store.QueryEvents(nostr.Filter{
-		Kinds: []int{888},
+		Kinds: []int{11888},
 		Tags:  nostr.TagMap{"p": []string{npub}},
 		Limit: 1,
 	})
@@ -274,7 +274,7 @@ func (m *SubscriptionManager) processHighTierPayment(
 
 	// Fetch current NIP-88 event to get existing state
 	events, err := m.store.QueryEvents(nostr.Filter{
-		Kinds: []int{888},
+		Kinds: []int{11888},
 		Tags:  nostr.TagMap{"p": []string{npub}},
 		Limit: 1,
 	})

--- a/lib/subscription/subscription.go
+++ b/lib/subscription/subscription.go
@@ -103,7 +103,7 @@ func (m *SubscriptionManager) InitializeSubscriber(npub string, mode string) err
 			Npub:    npub,
 			Address: addressStr,
 		}
-		
+
 		if err := m.createNIP88EventIfNotExists(subscriber, tierLimitStr, expirationDate, &storageInfo); err != nil {
 			log.Printf("Error creating NIP-88 event asynchronously for %s: %v", npub, err)
 		} else {
@@ -129,7 +129,7 @@ func (m *SubscriptionManager) InitializeSubscriber(npub string, mode string) err
 func (m *SubscriptionManager) UpdateStorageUsage(npub string, newBytes int64) error {
 	// Fetch current NIP-88 event data
 	events, err := m.store.QueryEvents(nostr.Filter{
-		Kinds: []int{888},
+		Kinds: []int{11888},
 		Tags: nostr.TagMap{
 			"p": []string{npub},
 		},
@@ -183,7 +183,7 @@ func (m *SubscriptionManager) UpdateStorageUsage(npub string, newBytes int64) er
 func (m *SubscriptionManager) CheckStorageAvailability(npub string, requestedBytes int64) error {
 	// Step 1: Fetch the user's NIP-88 event
 	events, err := m.store.QueryEvents(nostr.Filter{
-		Kinds: []int{888},
+		Kinds: []int{11888},
 		Tags: nostr.TagMap{
 			"p": []string{npub},
 		},
@@ -296,15 +296,15 @@ func (m *SubscriptionManager) RequestNewAddresses(count int) error {
 	return nil
 }
 
-// CheckAndUpdateSubscriptionEvent checks if a kind 888 event needs to be updated
+// CheckAndUpdateSubscriptionEvent checks if a kind 11888 event needs to be updated
 // based on current allowed users settings and updates it if necessary
 func (m *SubscriptionManager) CheckAndUpdateSubscriptionEvent(event *nostr.Event) (*nostr.Event, error) {
-	// Only process kind 888 events
-	if event.Kind != 888 {
+	// Only process kind 11888 events
+	if event.Kind != 11888 {
 		return event, nil
 	}
 
-	log.Printf("Checking kind 888 event for updates based on free tier status")
+	log.Printf("Checking kind 11888 event for updates based on free tier status")
 
 	// Get the pubkey from the p tag
 	var pubkey string
@@ -316,7 +316,7 @@ func (m *SubscriptionManager) CheckAndUpdateSubscriptionEvent(event *nostr.Event
 	}
 
 	if pubkey == "" {
-		return event, fmt.Errorf("no pubkey found in kind 888 event")
+		return event, fmt.Errorf("no pubkey found in kind 11888 event")
 	}
 
 	// Get subscription status
@@ -449,14 +449,14 @@ func (m *SubscriptionManager) CheckAndUpdateSubscriptionEvent(event *nostr.Event
 		return event, fmt.Errorf("failed to store updated event: %v", err)
 	}
 
-	log.Printf("Successfully updated kind 888 event for pubkey %s", pubkey)
+	log.Printf("Successfully updated kind 11888 event for pubkey %s", pubkey)
 	return updatedEvent, nil
 }
 
-// UpdateNpubSubscriptionEvent updates the kind 888 event for a specific npub with new tier information
-// This is called when access control lists are updated and we need to sync the kind 888 events
+// UpdateNpubSubscriptionEvent updates the kind 11888 event for a specific npub with new tier information
+// This is called when access control lists are updated and we need to sync the kind 11888 events
 func (m *SubscriptionManager) UpdateNpubSubscriptionEvent(npub, tierName string) error {
-	log.Printf("Updating kind 888 event for npub %s with tier %s", npub, tierName)
+	log.Printf("Updating kind 11888 event for npub %s with tier %s", npub, tierName)
 
 	// Load allowed users settings to get tier configuration
 	var allowedUsersSettings types.AllowedUsersSettings

--- a/lib/web/handlers/handler_paid_subscribers.go
+++ b/lib/web/handlers/handler_paid_subscribers.go
@@ -188,9 +188,9 @@ func GetSubscribersFromEvents(c *fiber.Ctx, store stores.Store) error {
 		return fmt.Errorf("error getting config: %v", err)
 	}
 
-	// Step 1: Get all kind 888 events (subscription events)
+	// Step 1: Get all kind 11888 events (subscription events)
 	subscriptionEvents, err := store.QueryEvents(nostr.Filter{
-		Kinds: []int{888},
+		Kinds: []int{11888},
 		Tags: nostr.TagMap{
 			"subscription_status": []string{"active"},
 		},

--- a/lib/web/handlers/settings/handler_relay_settings.go
+++ b/lib/web/handlers/settings/handler_relay_settings.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/HORNET-Storage/go-hornet-storage-lib/lib/signing"
 	"github.com/HORNET-Storage/hornet-storage/lib/config"
-	"github.com/HORNET-Storage/hornet-storage/lib/handlers/nostr/kind411"
+	"github.com/HORNET-Storage/hornet-storage/lib/handlers/nostr/kind10411"
 	"github.com/HORNET-Storage/hornet-storage/lib/stores"
 	"github.com/HORNET-Storage/hornet-storage/lib/subscription"
 	"github.com/HORNET-Storage/hornet-storage/lib/types"
@@ -291,11 +291,11 @@ func UpdateSettings(c *fiber.Ctx, store stores.Store) error {
 		}
 	}
 
-	// Check if relay settings are being updated (affects kind 411 relay info)
+	// Check if relay settings are being updated (affects kind 10411 relay info)
 	relaySettingsUpdated := false
 	if _, exists := settings["relay"]; exists {
 		relaySettingsUpdated = true
-		log.Println("Relay settings updated, will regenerate kind 411 event...")
+		log.Println("Relay settings updated, will regenerate kind 10411 event...")
 	}
 
 	// Update each setting
@@ -323,9 +323,9 @@ func UpdateSettings(c *fiber.Ctx, store stores.Store) error {
 		subscription.ScheduleBatchUpdateAfter(5 * time.Second)
 	}
 
-	// If either allowed_users or relay settings were updated, regenerate kind 411 event
+	// If either allowed_users or relay settings were updated, regenerate kind 10411 event
 	if allowedUsersUpdated || relaySettingsUpdated {
-		// Regenerate kind 411 event immediately in a goroutine
+		// Regenerate kind 10411 event immediately in a goroutine
 		if store != nil {
 			go func() {
 				var reason string
@@ -337,7 +337,7 @@ func UpdateSettings(c *fiber.Ctx, store stores.Store) error {
 					reason = "relay settings changes"
 				}
 
-				log.Printf("Regenerating kind 411 event due to %s...", reason)
+				log.Printf("Regenerating kind 10411 event due to %s...", reason)
 
 				// Get the private and public keys from viper (same way as main.go does)
 				serializedPrivateKey := viper.GetString("relay.private_key")
@@ -354,14 +354,14 @@ func UpdateSettings(c *fiber.Ctx, store stores.Store) error {
 
 				// Use the existing store instance passed from the web server
 				// This avoids the database lock issue
-				if err := kind411.CreateKind411Event(privateKey, publicKey, store); err != nil {
-					log.Printf("Error regenerating kind 411 event: %v", err)
+				if err := kind10411.CreateKind10411Event(privateKey, publicKey, store); err != nil {
+					log.Printf("Error regenerating kind 10411 event: %v", err)
 				} else {
-					log.Printf("Successfully regenerated kind 411 event")
+					log.Printf("Successfully regenerated kind 10411 event")
 				}
 			}()
 		} else {
-			log.Printf("Warning: Store not available, skipping kind 411 regeneration")
+			log.Printf("Warning: Store not available, skipping kind 10411 regeneration")
 		}
 	}
 

--- a/lib/web/handlers/settings/handler_relay_settings.go
+++ b/lib/web/handlers/settings/handler_relay_settings.go
@@ -318,7 +318,7 @@ func UpdateSettings(c *fiber.Ctx, store stores.Store) error {
 	if allowedUsersUpdated {
 		log.Println("Allowed users settings updated, triggering event regeneration...")
 
-		// Schedule batch update of kind 888 events after a short delay
+		// Schedule batch update of kind 11888 events after a short delay
 		// This allows for multiple rapid setting changes to be batched together
 		subscription.ScheduleBatchUpdateAfter(5 * time.Second)
 	}

--- a/services/server/port/main.go
+++ b/services/server/port/main.go
@@ -46,6 +46,7 @@ import (
 	"github.com/HORNET-Storage/hornet-storage/lib/handlers/nostr/kind10001"
 	"github.com/HORNET-Storage/hornet-storage/lib/handlers/nostr/kind10002"
 	"github.com/HORNET-Storage/hornet-storage/lib/handlers/nostr/kind10010"
+	"github.com/HORNET-Storage/hornet-storage/lib/handlers/nostr/kind10411"
 	"github.com/HORNET-Storage/hornet-storage/lib/handlers/nostr/kind1063"
 	"github.com/HORNET-Storage/hornet-storage/lib/handlers/nostr/kind11011"
 	"github.com/HORNET-Storage/hornet-storage/lib/handlers/nostr/kind117"
@@ -61,7 +62,6 @@ import (
 	"github.com/HORNET-Storage/hornet-storage/lib/handlers/nostr/kind30023"
 	"github.com/HORNET-Storage/hornet-storage/lib/handlers/nostr/kind30078"
 	"github.com/HORNET-Storage/hornet-storage/lib/handlers/nostr/kind30079"
-	"github.com/HORNET-Storage/hornet-storage/lib/handlers/nostr/kind411"
 	"github.com/HORNET-Storage/hornet-storage/lib/handlers/nostr/kind5"
 	"github.com/HORNET-Storage/hornet-storage/lib/handlers/nostr/kind6"
 	"github.com/HORNET-Storage/hornet-storage/lib/handlers/nostr/kind7"
@@ -376,9 +376,9 @@ func main() {
 		logging.Warn("Warning: Statistics store not available, access control not initialized")
 	}
 
-	// Create and store kind 411 event
-	if err := kind411.CreateKind411Event(privateKey, publicKey, store); err != nil {
-		logging.Errorf("Failed to create kind 411 event: %v", err)
+	// Create and store kind 10411 event
+	if err := kind10411.CreateKind10411Event(privateKey, publicKey, store); err != nil {
+		logging.Errorf("Failed to create kind 10411 event: %v", err)
 		return
 	}
 

--- a/services/server/port/main.go
+++ b/services/server/port/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -331,14 +330,14 @@ func main() {
 	)
 	logging.Info("Global subscription manager initialized successfully")
 
-	// Batch update existing kind 888 events on startup to ensure they reflect current config
-	logging.Info("Updating existing kind 888 events to reflect current configuration...")
+	// Batch update existing kind 11888 events on startup to ensure they reflect current config
+	logging.Info("Updating existing kind 11888 events to reflect current configuration...")
 	if manager := subscription.GetGlobalManager(); manager != nil {
 		go func() {
 			if err := manager.BatchUpdateAllSubscriptionEvents(); err != nil {
-				logging.Errorf("Failed to update existing kind 888 events on startup: %v", err)
+				logging.Errorf("Failed to update existing kind 11888 events on startup: %v", err)
 			} else {
-				logging.Info("Successfully updated existing kind 888 events on startup")
+				logging.Info("Successfully updated existing kind 11888 events on startup")
 			}
 		}()
 	}
@@ -346,6 +345,24 @@ func main() {
 	// Initialize daily free tier subscription renewal
 	logging.Info("Initializing daily free tier subscription renewal...")
 	subscription.InitDailyFreeSubscriptionRenewal()
+
+	// Validate subscription mode configuration and ensure address availability
+	if settings.AllowedUsersSettings.Mode == "subscription" {
+		logging.Info("Relay is in subscription mode - validating Bitcoin address availability...")
+		if manager := subscription.GetGlobalManager(); manager != nil {
+			if err := validateSubscriptionModeStartup(manager, store); err != nil {
+				logging.Fatal("Subscription mode validation failed", map[string]interface{}{
+					"error": err,
+				})
+			}
+		} else {
+			logging.Fatal("Subscription manager not available for subscription mode validation")
+		}
+	} else {
+		logging.Info("Relay not in subscription mode - skipping Bitcoin address validation", map[string]interface{}{
+			"mode": settings.AllowedUsersSettings.Mode,
+		})
+	}
 
 	// Initialize the global access control
 	logging.Info("Initializing global access control...")
@@ -561,4 +578,49 @@ func main() {
 	}()
 
 	wg.Wait()
+}
+
+// validateSubscriptionModeStartup ensures that when the relay starts in subscription mode,
+// all existing Kind 11888 events have Bitcoin addresses assigned and the wallet service is available
+func validateSubscriptionModeStartup(manager *subscription.SubscriptionManager, store *badgerhold.BadgerholdStore) error {
+	logging.Info("Starting subscription mode validation at startup...")
+
+	// Step 1: Check wallet service connectivity using subscription package function
+	walletHealthy, err := subscription.CheckWalletServiceHealth()
+	if err != nil || !walletHealthy {
+		return fmt.Errorf("wallet service is not available - cannot start in subscription mode: %v", err)
+	}
+	logging.Info("Wallet service connectivity verified")
+
+	// Step 2: Check if there are existing Kind 11888 events without Bitcoin addresses
+	statsStore := store.GetStatsStore()
+	if statsStore == nil {
+		return fmt.Errorf("statistics store not available")
+	}
+
+	usersWithoutAddresses, err := statsStore.CountUsersWithoutBitcoinAddresses()
+	if err != nil {
+		return fmt.Errorf("failed to count users without Bitcoin addresses: %v", err)
+	}
+
+	if usersWithoutAddresses == 0 {
+		logging.Info("All existing users already have Bitcoin addresses assigned")
+		return nil
+	}
+
+	logging.Info("Found users without Bitcoin addresses, starting migration", map[string]interface{}{
+		"users_needing_addresses": usersWithoutAddresses,
+	})
+
+	// Step 3: Run the batch allocation to assign addresses to existing users
+	// This will handle ensuring sufficient addresses are available
+	if err := manager.AllocateBitcoinAddressesForExistingUsers(); err != nil {
+		return fmt.Errorf("failed to allocate Bitcoin addresses for existing users: %v", err)
+	}
+
+	logging.Info("Successfully completed subscription mode startup validation", map[string]interface{}{
+		"users_processed": usersWithoutAddresses,
+	})
+
+	return nil
 }


### PR DESCRIPTION
# Refactor NIP Kinds & Add Targeted Kind 11888 Updates for Invite-Only Mode

  ## Summary

  This PR includes two major improvements: updating NIP event kinds to match current specifications and implementing targeted subscription
  event updates for invite-only mode tier changes.

  ## Changes Made

  ### NIP Kind Specification Updates
  - **Kind 888 → 11888**: Updated all subscription event references throughout codebase
    - Updated 11 files including documentation, handlers, batch processing, and payment logic
    - Changed logs, comments, and function names for consistency
    - Modified filter handling and event creation logic
  - **Kind 411 → 10411**: Updated all relay information event references
    - Renamed handler directory from `kind411` to `kind10411`
    - Updated imports, function calls, and documentation
    - Modified settings handlers and server startup logic

  ### Targeted Subscription Updates for Invite-Only Mode
  - **New Function**: `UpdateUserSubscriptionFromDatabase()` implementing correct data flow:
    1. Look up user's assigned tier from database
    2. Look up tier specifications from configuration
    3. Update user's kind 11888 event with new storage allocation
  - **Immediate Trigger**: Added automatic update in `AddAllowedUser` API endpoint
  - **Storage Preservation**: Maintains user's current storage usage when updating tier allocations
  - **Efficient Updates**: Only updates specific user instead of batch processing all users