### PR TITLE
Fix/image moderation config conditional

### DIFF
--- a/lib/stores/badgerhold/badgerhold.go
+++ b/lib/stores/badgerhold/badgerhold.go
@@ -22,6 +22,7 @@ import (
 	merkle_dag "github.com/HORNET-Storage/Scionic-Merkle-Tree/dag"
 	types "github.com/HORNET-Storage/hornet-storage/lib"
 
+	"github.com/HORNET-Storage/hornet-storage/lib/config"
 	"github.com/HORNET-Storage/hornet-storage/lib/logging"
 	stores "github.com/HORNET-Storage/hornet-storage/lib/stores"
 	"github.com/HORNET-Storage/hornet-storage/lib/stores/statistics"
@@ -30,7 +31,6 @@ import (
 	"github.com/timshannon/badgerhold/v4"
 
 	lib_types "github.com/HORNET-Storage/go-hornet-storage-lib/lib"
-	"github.com/HORNET-Storage/hornet-storage/lib/transports/websocket"
 )
 
 const (
@@ -700,26 +700,14 @@ func (store *BadgerholdStore) StoreEvent(ev *nostr.Event) error {
 		}
 	}
 
-	// Check for images that need moderation
-	// Extract image URLs from the event using our image extractor
-	imageURLs := ExtractImageURLsFromEvent(ev)
-	if len(imageURLs) > 0 {
-		// Check if we should bypass moderation for exclusive mode
-		if ac := websocket.GetAccessControl(); ac != nil {
-			if settings := ac.GetSettings(); settings != nil && strings.ToLower(settings.Mode) == "exclusive" {
-				logging.Infof("Event %s contains %d images, but skipping moderation in exclusive mode", ev.ID, len(imageURLs))
-				// Skip moderation entirely for exclusive mode
-			} else {
-				// Continue with moderation for free and paid modes
-				logging.Infof("Event %s contains %d images, adding to moderation queue", ev.ID, len(imageURLs))
-				err = store.AddToPendingModeration(ev.ID, imageURLs)
-				if err != nil {
-					logging.Infof("Failed to add event %s to pending moderation: %v", ev.ID, err)
-				}
-			}
-		} else {
-			// Fallback to current behavior if access control not available
-			logging.Infof("Event %s contains %d images, adding to moderation queue (fallback)", ev.ID, len(imageURLs))
+	// Check for images that need moderation - only if image moderation is enabled
+	if cfg, err := config.GetConfig(); err != nil {
+		logging.Infof("Failed to get config for image moderation check: %v", err)
+	} else if cfg.ContentFiltering.ImageModeration.Enabled {
+		// Extract image URLs from the event using our image extractor
+		imageURLs := ExtractImageURLsFromEvent(ev)
+		if len(imageURLs) > 0 {
+			logging.Infof("Event %s contains %d images, adding to moderation queue", ev.ID, len(imageURLs))
 			err = store.AddToPendingModeration(ev.ID, imageURLs)
 			if err != nil {
 				logging.Infof("Failed to add event %s to pending moderation: %v", ev.ID, err)

--- a/lib/web/handlers/settings/handler_relay_settings.go
+++ b/lib/web/handlers/settings/handler_relay_settings.go
@@ -27,6 +27,9 @@ func GetSettings(c *fiber.Ctx) error {
 	// Return the entire config as JSON
 	settings := viper.AllSettings()
 
+	// Clean prefixed keys before sending to frontend
+	cleanSettingsForFrontend(settings)
+
 	// Log each major section
 	if _, ok := settings["subscriptions"]; ok {
 		// logging.Infof("subscriptions: %+v", subscriptions)
@@ -226,6 +229,13 @@ func UpdateSettings(c *fiber.Ctx, store stores.Store) error {
 
 	// NORMALIZATION: Ensure proper data types before saving
 	normalizeDataTypes(settings)
+
+	// Log the incoming settings for debugging
+	logging.Infof("Received settings: %+v", settings)
+
+	// CLEANUP: Convert incoming prefixed data to clean structure
+	convertToCleanStructure(settings)
+	logging.Infof("After cleanup: %+v", settings)
 
 	// Check if allowed_users settings are being updated (affects subscription tiers)
 	allowedUsersUpdated := false
@@ -509,4 +519,87 @@ func UpdateSettingValue(c *fiber.Ctx) error {
 		"key":     key,
 		"value":   value,
 	})
+}
+
+// cleanSettingsForFrontend removes prefixed keys before sending to frontend
+func cleanSettingsForFrontend(settings map[string]interface{}) {
+	for _, sectionValue := range settings {
+		if sectionMap, ok := sectionValue.(map[string]interface{}); ok {
+			for subSectionName, subSectionValue := range sectionMap {
+				if subSectionMap, ok := subSectionValue.(map[string]interface{}); ok {
+					removePrefixedKeys(subSectionMap, subSectionName)
+				}
+			}
+		}
+	}
+}
+
+// convertToCleanStructure converts incoming prefixed data to clean structure
+func convertToCleanStructure(settings map[string]interface{}) {
+	for _, sectionValue := range settings {
+		if sectionMap, ok := sectionValue.(map[string]interface{}); ok {
+			for subSectionName, subSectionValue := range sectionMap {
+				if subSectionMap, ok := subSectionValue.(map[string]interface{}); ok {
+					convertPrefixedToClean(subSectionMap, subSectionName)
+				}
+			}
+		}
+	}
+}
+
+// removePrefixedKeys removes all prefixed keys, keeping only clean ones
+func removePrefixedKeys(m map[string]interface{}, sectionName string) {
+	var prefix string
+	if sectionName == "text_filter" {
+		prefix = "content_filter_"
+	} else {
+		prefix = sectionName + "_"
+	}
+
+	keysToDelete := []string{}
+	for key := range m {
+		if strings.HasPrefix(key, prefix) {
+			keysToDelete = append(keysToDelete, key)
+		}
+	}
+
+	for _, key := range keysToDelete {
+		delete(m, key)
+	}
+}
+
+// convertPrefixedToClean converts prefixed keys to clean ones and removes prefixed versions
+func convertPrefixedToClean(m map[string]interface{}, sectionName string) {
+	var prefix string
+	if sectionName == "text_filter" {
+		prefix = "content_filter_"
+	} else {
+		prefix = sectionName + "_"
+	}
+
+	conversions := make(map[string]interface{})
+	keysToDelete := []string{}
+
+	// Find prefixed keys and prepare clean versions
+	for key, value := range m {
+		if strings.HasPrefix(key, prefix) {
+			cleanKey := strings.TrimPrefix(key, prefix)
+			// Only add if clean key doesn't already exist
+			if _, exists := m[cleanKey]; !exists {
+				conversions[cleanKey] = value
+				logging.Infof("Converting %s -> %s", key, cleanKey)
+			}
+			keysToDelete = append(keysToDelete, key)
+		}
+	}
+
+	// Add clean keys
+	for cleanKey, value := range conversions {
+		m[cleanKey] = value
+	}
+
+	// Remove prefixed keys
+	for _, key := range keysToDelete {
+		delete(m, key)
+	}
 }


### PR DESCRIPTION
## Summary

  This PR improves image moderation and settings processing with two key fixes:

  - **Make image moderation conditional on config setting**: Image moderation now only activates when
  `content_filtering.image_moderation.enabled` is true, regardless of relay mode
  - **Improve settings processing with frontend data cleanup**: Add functions to properly handle prefixed form data between frontend and
  backend

  ## Changes Made

  ### Image Moderation Config Dependency
  - Add config import to badgerhold store
  - Check `ContentFiltering.ImageModeration.Enabled` before activating moderation
  - Simplify image moderation logic by removing mode-based complexity
  - Remove dependency on websocket access control for moderation decisions

  ### Settings Processing Improvements
  - Add `cleanSettingsForFrontend()` to remove prefixed keys before sending to frontend
  - Add `convertToCleanStructure()` to handle incoming prefixed form data
  - Add helper functions `removePrefixedKeys()` and `convertPrefixedToClean()`
  - Improve debugging with logging for incoming settings and after cleanup