### PR TITLE
Update build-panel.sh

### DIFF
--- a/build-panel.sh
+++ b/build-panel.sh
@@ -32,7 +32,11 @@ GENERATE_SOURCEMAP=false NODE_ENV=production yarn build
 # Copy built files to web directory
 echo "📋 Copying files to web directory..."
 cd ..
+# Create web directory if it doesn't exist
+mkdir -p web
+# Clear any existing files
 rm -rf web/*
+# Copy built files
 cp -r panel-source/build/* web/
 
 echo "✅ Panel built and deployed successfully!"


### PR DESCRIPTION
Updated build-panel.sh to create the web directory if it doesn't exist:

Added mkdir -p web before the copy operation
This ensures the directory structure matches what the web server expects The fix allows the build script to run successfully even on fresh installations