### PR TITLE
fix: Prevent private key erasure on settings update

### DIFF
--- a/lib/web/handlers/settings/handler_relay_settings.go
+++ b/lib/web/handlers/settings/handler_relay_settings.go
@@ -374,18 +374,9 @@ func UpdateSettings(c *fiber.Ctx, store stores.Store) error {
 				if err != nil {
 					logging.Infof("Error calculating supported NIPs from kinds: %v", err)
 				} else {
-					// Update supported_nips in relay settings (create relay section if it doesn't exist)
-					if _, exists := settings["relay"]; !exists {
-						settings["relay"] = make(map[string]interface{})
-						logging.Infof("DEBUG: Created relay section in settings")
-					}
-					if relayMap, ok := settings["relay"].(map[string]interface{}); ok {
-						relayMap["supported_nips"] = supportedNIPs
-						logging.Infof("Updated supported_nips based on kind_whitelist: %v", supportedNIPs)
-					}
-
-					// Also update viper directly to ensure it's saved to config.yaml
+					// Update supported_nips directly in viper to avoid overwriting other relay settings
 					viper.Set("relay.supported_nips", supportedNIPs)
+					logging.Infof("Updated supported_nips based on kind_whitelist: %v", supportedNIPs)
 				}
 			}
 		}


### PR DESCRIPTION
The settings handler was creating a new, empty relay configuration object when the kind whitelist was updated, which would overwrite the existing settings and erase the private key. This fix ensures that the existing configuration is modified in memory rather than being replaced.